### PR TITLE
Fix compressing the image twice

### DIFF
--- a/android/src/main/kotlin/dev/ms/convert_native_img_stream/ConvertNativeImgStreamPlugin.kt
+++ b/android/src/main/kotlin/dev/ms/convert_native_img_stream/ConvertNativeImgStreamPlugin.kt
@@ -42,11 +42,12 @@ class ConvertNativeImgStreamPlugin: FlutterPlugin, MethodCallHandler {
     val bytes: ByteArray? = arg?.get("bytes") as? ByteArray
     val width: Int? = arg?.get("width") as? Int
     val height: Int? = arg?.get("height") as? Int
-    val quality: Int = arg?.get("quality") as? Int ?: 100
+
+    var quality: Int = 100 
 
     if(bytes == null || width == null || height == null) {
       result.error("Null argument", "bytes, width, height must not be null", null)
-      return
+      retu
     }
 
     Thread {

--- a/android/src/main/kotlin/dev/ms/convert_native_img_stream/ConvertNativeImgStreamPlugin.kt
+++ b/android/src/main/kotlin/dev/ms/convert_native_img_stream/ConvertNativeImgStreamPlugin.kt
@@ -47,7 +47,7 @@ class ConvertNativeImgStreamPlugin: FlutterPlugin, MethodCallHandler {
 
     if(bytes == null || width == null || height == null) {
       result.error("Null argument", "bytes, width, height must not be null", null)
-      retu
+      return
     }
 
     Thread {

--- a/lib/convert_native_img_stream.dart
+++ b/lib/convert_native_img_stream.dart
@@ -45,7 +45,7 @@ class ConvertNativeImgStream {
     Uint8List? jpegData = imgBytes;
     if (Platform.isAndroid) {
       jpegData = await ConvertNativeImgStreamPlatform.instance.convert(
-          imgBytes, width, height, quality
+          imgBytes, width, height 
       );
     }
     return compute((List<dynamic> params) async {

--- a/lib/convert_native_img_stream_method_channel.dart
+++ b/lib/convert_native_img_stream_method_channel.dart
@@ -22,7 +22,6 @@ class MethodChannelConvertNativeImgStream extends ConvertNativeImgStreamPlatform
       Uint8List imgBytes,
       int width,
       int height,
-      int quality
     ) async {
     if(Platform.isIOS) {
       throw UnimplementedError('convert(*) has not been implemented for iOS');
@@ -31,7 +30,6 @@ class MethodChannelConvertNativeImgStream extends ConvertNativeImgStreamPlatform
       "bytes": imgBytes,
       "width": width,
       "height": height,
-      "quality": quality
     });
     return result;
   }

--- a/lib/convert_native_img_stream_platform_interface.dart
+++ b/lib/convert_native_img_stream_platform_interface.dart
@@ -32,7 +32,6 @@ abstract class ConvertNativeImgStreamPlatform extends PlatformInterface {
       Uint8List imgBytes,
       int width,
       int height,
-      int quality
   ) {
     throw UnimplementedError('convert(*) has not been implemented.');
   }


### PR DESCRIPTION
On Android the image is first compressed to 100% and then to the compression quality that was chosen. This prevents over-compression.